### PR TITLE
bugfix: if records_per_thread is 0, set to 1

### DIFF
--- a/ARC/classifier.py
+++ b/ARC/classifier.py
@@ -732,6 +732,12 @@ class SeqClassifier:
         else:
             num_records = len(seq_records)
             records_per_thread = num_records // self.num_threads
+
+            # If records_per_thread is 0, set it and num_threads to 1
+            if records_per_thread == 0:
+                records_per_thread = 1
+                self.num_threads = 1
+
             # Create chunks of sequences to be processed by each thread
             chunks = [seq_records[i:i + records_per_thread] for i in range(0, num_records, records_per_thread)]
             with mp.Pool(processes=self.num_threads) as pool:


### PR DESCRIPTION
Errors occasionally due to records_per_thread being 0. This fixes it by forcing a 1 if the number of threads is greater than the number of records.